### PR TITLE
Add itr del

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Remits  &nbsp;![Rust](https://github.com/badtuple/remits/workflows/Rust/badge.svg) [![Discord](https://img.shields.io/discord/691125113659195474)](https://discord.gg/gSVR24K)
-======
+# Remits  &nbsp;![Rust](https://github.com/badtuple/remits/workflows/Rust/badge.svg) [![Discord](https://img.shields.io/discord/691125113659195474)](https://discord.gg/gSVR24K)
 
 Remote Iterator Server
 
@@ -49,7 +48,6 @@ resume from that spot at a later time.
 Want to contribute to Remits?
 Feel free to jump into [our chat](https://discord.gg/gSVR24K) or open a github issue. We'll be happy to help find a good place to get started!
 Remits is still young, so there's alot of low hanging fruit and definitional work to do.
-
 
 ## Questions
 

--- a/design/README.md
+++ b/design/README.md
@@ -1,5 +1,4 @@
-Design
-======
+# Design
 
 This document is a high level description of Remits' protocol/api, operations,
 and some intended features. It's to help communicate intent and direction during
@@ -36,9 +35,10 @@ a custom audit log where Messages are arbitray binary objects.
 ## Log
 
 Logs can only be:
-  * Created
-  * Deleted
-  * Pushed to
+
+* Created
+* Deleted
+* Pushed to
 
 You cannot delete or update a Message from a log. You can only push a new one.
 You cannot query a log directly. You must always use an iterator.
@@ -49,7 +49,8 @@ Iterators query Messages from Logs.
 
 You define an Iterator via a Lua function (choice of Lua is up for discussion.)
 There are three types of Iterators:
-  1. A *Map* Iterator transforms each Message before sending it to the client. 
+
+  1. A *Map* Iterator transforms each Message before sending it to the client.
   2. A *Filter* Iterator takes each Message and returns a boolean. If `false`
      is returned, the Message is not sent to the client. If `true` is returned,
      the Message is sent to the client.
@@ -102,4 +103,3 @@ Command                                             | Description
 `IDX ADD <log name> <iterator name> <iterator type> <lua function>` | Create an Indexed Iterator
 `ITR NXT <iterator name> <message offset> <count>`      | Get `count` Messages after a specific Offset. Offset `0` refers to the first Message, and Offest `-1` refers to the last Message.
 `ITR PRV <iterator name> <message offset> <count>`      | Get `count` Messages before a specific Offset. Offset `-1` refers to the last Message.
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 #[cfg(test)]
-mod tests {
+mod main {
     //use super::*;
     // TODO
     #[test]


### PR DESCRIPTION
I started to write this because i thought "log groups" (LOG DEL)  were being deleting without removing iterators(untrue). This is still functionality i think people would want so they dont have a ton of old iterators sitting around

PS the readme changes are just from some linter i had installed in vscode