### PR TITLE
Destringify Tests

### DIFF
--- a/src/parser/commands.rs
+++ b/src/parser/commands.rs
@@ -1,0 +1,37 @@
+#[derive(Debug, Eq, PartialEq)]
+pub enum Command {
+    LogAdd(String),
+    LogDel(String),
+    MsgAdd {
+        log: String,
+        msg: Vec<u8>,
+    },
+    ItrAdd {
+        log: String,
+        name: String,
+        kind: String,
+        func: String,
+    },
+    ItrDel {
+        log: String,
+        name: String,
+    },
+}
+
+impl Command {
+    pub fn new_itr_add(log: &str, name: &str, kind: &str, func: &str) -> Self {
+        Self::ItrAdd {
+            log: log.to_owned(),
+            name: name.to_owned(),
+            kind: kind.to_owned(),
+            func: func.to_owned(),
+        }
+    }
+
+    pub fn new_itr_del(log: &str, name: &str) -> Self {
+        Self::ItrDel {
+            log: log.to_owned(),
+            name: name.to_owned(),
+        }
+    }
+}

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     UnrecognizedCommand,
     MalformedCommand,


### PR DESCRIPTION
We were converting types into strings and testing the strings in a few places. That was ok ad-hoc, but it'll get messy and super verbose as the crate grows.