### PR TITLE
Integration tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Build
       run: cargo build --bin remits --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --bin --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Build
       run: cargo build --bin remits --verbose
     - name: Run tests
-      run: cargo test --bin --verbose
+      run: cargo test --bins --verbose

--- a/src/db/errors.rs
+++ b/src/db/errors.rs
@@ -9,6 +9,6 @@ pub enum Error {
 
 impl From<Error> for Bytes {
     fn from(e: Error) -> Self {
-        format!("{:?}", e).into()
+        format!("err {:?}", e).into()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,17 +88,3 @@ async fn main() -> Result<(), Box<dyn Error>> {
         debug!("{:?}", db);
     }
 }
-
-#[cfg(test)]
-mod main {
-    //use super::*;
-    // TODO
-    #[test]
-    fn test_main() {}
-    // TODO
-    #[test]
-    fn test_handle_socket() {}
-    // TODO
-    #[test]
-    fn test_setup_logger() {}
-}

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -14,6 +14,6 @@ pub enum Error {
 
 impl From<Error> for Bytes {
     fn from(e: Error) -> Self {
-        format!("{:?}", e).into()
+        format!("err {:?}", e).into()
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,41 @@
+/// All tests in this folder assume a server running on localhost:4242
+use std::io;
+use std::io::Write;
+
+use futures::SinkExt;
+use tokio::net::TcpStream;
+use tokio::stream::StreamExt;
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+use bytes::Bytes;
+
+static LOCAL_REMITS: &str = "localhost:4242";
+
+#[tokio::test]
+async fn test_can_connect_to_server() {
+    TcpStream::connect(LOCAL_REMITS)
+        .await
+        .expect("could not connect to localhost:4242");
+}
+
+#[tokio::test]
+async fn test_can_create_log() {
+    let stream = TcpStream::connect(LOCAL_REMITS)
+        .await
+        .expect("could not connect to localhost:4242");
+
+    let mut framer = Framed::new(stream, LengthDelimitedCodec::new());
+
+    framer
+        .send(Bytes::from("LOG ADD test_log"))
+        .await
+        .expect("could not sent command");
+
+    let result = framer
+        .next()
+        .await
+        .expect("no response from remits")
+        .expect("could not understand response");
+
+    assert_eq!(&*result, b"ok");
+}


### PR DESCRIPTION
This is a small PR that just sets up the pattern for integration tests.

Rust's usual integration test pattern only works for libraries. When you look at how to set things up, they suggest having a thin `main` function that calls a fully fleshed out library and then integration testing the _library_.  For a database I don't consider that ok...we'll want to run against an actual database so that we include networking and disk and everything.  So right now the integration tests assume a locally running database, which means we can't run it in CI (without alot more effort.)  If this gets annoying, we can switch to the library method.

Obviously these tests aren't exhaustive. It's just to get the pattern in place. I'll be fleshing these out as I implement the changes to Log and implement Iterators.