### PR TITLE
Logs always contain MessagePack encoded values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
 name = "bytes"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +456,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,10 +572,43 @@ dependencies = [
  "env_logger",
  "futures",
  "log",
+ "rmp-serde",
+ "rmpv",
  "serde",
  "serde_json",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f10b46df14cf1ee1ac7baa4d2fbc2c52c0622a4b82fa8740e37bc452ac0184f"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c1ee98f14fe8b8e9c5ea13d25da7b2a1796169202c57a09d7288de90d56222b"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
+name = "rmpv"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e5078dd8691b0811b14fbd2d78358f7fc68e83b98ba6f16488bf77694e9fe2"
+dependencies = [
+ "num-traits",
+ "rmp",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 confy = "0.4.0"
 argh = "0.1.3"
+rmp-serde = "0.14.3"
+rmpv = "0.4.4"

--- a/src/db/errors.rs
+++ b/src/db/errors.rs
@@ -5,6 +5,7 @@ pub enum Error {
     LogDoesNotExist,
     ItrExistsWithSameName,
     ItrDoesNotExist,
+    MsgNotValidMessagePack,
 }
 
 impl From<Error> for Bytes {

--- a/src/db/iters.rs
+++ b/src/db/iters.rs
@@ -1,0 +1,40 @@
+#[derive(Debug, PartialEq, Eq)]
+pub struct Itr {
+    pub log: String,
+    pub name: String,
+    pub func: String,
+    pub kind: ItrKind,
+}
+
+impl Itr {}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ItrKind {
+    Map,
+    Filter,
+    Reduce,
+}
+
+impl PartialEq<String> for ItrKind {
+    fn eq(&self, other: &String) -> bool {
+        use ItrKind::*;
+        let itr_kind = match &**other {
+            "map" => Map,
+            "filter" => Filter,
+            "reduce" => Reduce,
+            _ => return false,
+        };
+
+        *self == itr_kind
+    }
+}
+
+pub fn string_to_kind_unchecked(s: String) -> ItrKind {
+    use ItrKind::*;
+    match &*s {
+        "map" => Map,
+        "filter" => Filter,
+        "reduce" => Reduce,
+        _ => panic!("string_to_kind_unchecked called with unvalidated string"),
+    }
+}

--- a/src/db/iters.rs
+++ b/src/db/iters.rs
@@ -1,3 +1,5 @@
+use super::logs::Log;
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Itr {
     pub log: String,
@@ -6,7 +8,13 @@ pub struct Itr {
     pub kind: ItrKind,
 }
 
-impl Itr {}
+impl Itr {
+    pub fn next(&self, log: &Log, offset: usize, count: usize) -> Vec<Vec<u8>> {
+        // TODO: this will panic if count is out of bounds.
+        // Implement `get` on Log and return None if nothing exists.
+        (0..count).map(|i| log[offset + i].clone()).collect()
+    }
+}
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ItrKind {

--- a/src/db/logs.rs
+++ b/src/db/logs.rs
@@ -45,7 +45,7 @@ mod tests {
     #[test]
     fn test_add_invalid_messagepack_msg() {
         let mut log = Log::new();
-        let buf = vec![ 0x93, 0x00, 0x2a ];
+        let buf = vec![0x93, 0x00, 0x2a];
         if let Ok(_) = log.add_msg(buf) {
             panic!("invalid messagepack was allowed into log");
         };

--- a/src/db/logs.rs
+++ b/src/db/logs.rs
@@ -31,9 +31,11 @@ impl Index<usize> for Log {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn test_add_valid_messagepack_msg() {
-        let log = Log::new();
+        let mut log = Log::new();
         let msg = vec![0x93, 0x00, 0x2a, 0xf7];
         if let Err(e) = log.add_msg(msg) {
             panic!("threw error for valid messagepack: {:?}", e);
@@ -42,10 +44,8 @@ mod tests {
 
     #[test]
     fn test_add_invalid_messagepack_msg() {
-        let log = Log::new();
-        // MessagePack encoded string,
-        // but bytes in string aren't valid utf8
-        let buf = vec![0xd9, 0x02, 0xc3, 0x28];
+        let mut log = Log::new();
+        let buf = vec![ 0x93, 0x00, 0x2a ];
         if let Ok(_) = log.add_msg(buf) {
             panic!("invalid messagepack was allowed into log");
         };

--- a/src/db/logs.rs
+++ b/src/db/logs.rs
@@ -32,8 +32,22 @@ impl Index<usize> for Log {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn test_add_valid_messagepack_msg() {}
+    fn test_add_valid_messagepack_msg() {
+        let log = Log::new();
+        let msg = vec![0x93, 0x00, 0x2a, 0xf7];
+        if let Err(e) = log.add_msg(msg) {
+            panic!("threw error for valid messagepack: {:?}", e);
+        };
+    }
 
     #[test]
-    fn test_add_invalid_messagepack_msg() {}
+    fn test_add_invalid_messagepack_msg() {
+        let log = Log::new();
+        // MessagePack encoded string,
+        // but bytes in string aren't valid utf8
+        let buf = vec![0xd9, 0x02, 0xc3, 0x28];
+        if let Ok(_) = log.add_msg(buf) {
+            panic!("invalid messagepack was allowed into log");
+        };
+    }
 }

--- a/src/db/logs.rs
+++ b/src/db/logs.rs
@@ -1,0 +1,39 @@
+use super::errors::Error;
+use rmpv::decode::value::read_value;
+use std::ops::Index;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Log {
+    data: Vec<Vec<u8>>,
+}
+
+impl Log {
+    pub fn new() -> Self {
+        Log { data: vec![] }
+    }
+
+    pub fn add_msg(&mut self, msg: Vec<u8>) -> Result<(), Error> {
+        if read_value(&mut &*msg).is_err() {
+            return Err(Error::MsgNotValidMessagePack);
+        }
+        self.data.push(msg);
+        Ok(())
+    }
+}
+
+impl Index<usize> for Log {
+    type Output = Vec<u8>;
+
+    fn index(&self, i: usize) -> &Vec<u8> {
+        &self.data[i]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_add_valid_messagepack_msg() {}
+
+    #[test]
+    fn test_add_invalid_messagepack_msg() {}
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,4 +1,5 @@
 mod errors;
+mod iters;
 mod logs;
 mod manifest;
 
@@ -192,7 +193,7 @@ mod tests {
         let _ = db.manifest.add_itr(
             "test".to_owned(),
             "fun".to_owned(),
-            "lua".to_owned(),
+            "map".to_owned(),
             "func".to_owned(),
         );
         assert_eq!(db.manifest.logs.len(), 1);
@@ -215,7 +216,7 @@ mod tests {
             .itr_add(
                 "test".to_owned(),
                 "std_dev avg users".to_owned(),
-                "bf".to_owned(),
+                "map".to_owned(),
                 "+[-->-[>>+>-----<<]<--<---]>-.>>>+.>>..+++[.>]<<<<.+++.------.<<-.>>>>+."
                     .to_owned(),
             )
@@ -224,7 +225,7 @@ mod tests {
             .itr_add(
                 "test2".to_owned(),
                 "std_dev avg users2".to_owned(),
-                "bf".to_owned(),
+                "map".to_owned(),
                 "+[-->-[>>+>-----<<]<--<---]>-.>>>+.>>..+++[.>]<<<<.+++.------.<<-.>>>>+."
                     .to_owned(),
             )
@@ -242,7 +243,7 @@ mod tests {
             .itr_add(
                 "test".to_owned(),
                 "std_dev avg users".to_owned(),
-                "bf".to_owned(),
+                "map".to_owned(),
                 "+[-->-[>>+>-----<<]<--<---]>-.>>>+.>>..+++[.>]<<<<.+++.------.<<-.>>>>+."
                     .to_owned(),
             )
@@ -257,7 +258,7 @@ mod tests {
         let _ = db.itr_add(
             "test".to_owned(),
             "std_dev avg users".to_owned(),
-            "bf".to_owned(),
+            "map".to_owned(),
             "+[-->-[>>+>-----<<]<--<---]>-.>>>+.>>..+++[.>]<<<<.+++.------.<<-.>>>>+.".to_owned(),
         );
         let out = db

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -44,6 +44,11 @@ impl DB {
                 func,
             } => self.itr_add(log, name, kind, func),
             ItrDel { log, name } => self.itr_del(log, name),
+            ItrNext {
+                name,
+                msg_id,
+                count,
+            } => self.itr_next(name, msg_id, count),
         }
     }
 
@@ -116,6 +121,10 @@ impl DB {
     fn itr_del(&mut self, log: String, name: String) -> Result<String, Error> {
         self.manifest.del_itr(log, name)?;
         Ok("ok".to_owned())
+    }
+
+    fn itr_next(&mut self, name: String, msg_id: usize, count: usize) -> Result<String, Error> {
+        unimplemented!();
     }
 }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,4 +1,5 @@
 mod errors;
+mod logs;
 mod manifest;
 
 use std::collections::hash_map::Entry;
@@ -6,6 +7,7 @@ use std::collections::HashMap;
 
 use crate::parser::Command;
 use errors::Error;
+use logs::Log;
 use manifest::Manifest;
 
 // Temporarily, everything will be done in memory until we're happy with the
@@ -56,7 +58,7 @@ impl DB {
     /// Adds a new log to the DB
     fn log_add(&mut self, name: String) -> Result<String, Error> {
         self.manifest.add_log(name.clone());
-        self.logs.entry(name).or_insert_with(|| vec![]);
+        self.logs.entry(name).or_insert_with(Log::new);
         Ok("ok".to_owned())
     }
 
@@ -74,7 +76,7 @@ impl DB {
     fn msg_add(&mut self, log: String, msg: Vec<u8>) -> Result<String, Error> {
         match self.logs.get_mut(&log) {
             Some(l) => {
-                l.push(msg);
+                l.add_msg(msg)?;
                 Ok("ok".to_owned())
             }
             None => Err(Error::LogDoesNotExist),
@@ -115,8 +117,6 @@ impl DB {
         Ok("ok".to_owned())
     }
 }
-
-type Log = Vec<Vec<u8>>;
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,9 +100,5 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
             Err(e) => error!("error accepting listener: {}", e),
         }
-
-        // Temporary full-state debugging for very early protocol dev.
-        // Will need to get extensive integration testing up asap.
-        debug!("{:?}", db);
     }
 }

--- a/src/parser/commands.rs
+++ b/src/parser/commands.rs
@@ -19,6 +19,11 @@ pub enum Command {
         log: String,
         name: String,
     },
+    ItrNext {
+        name: String,
+        msg_id: usize,
+        count: usize,
+    },
 }
 
 impl Command {

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -10,6 +10,8 @@ pub enum Error {
     ItrNameNotUtf8,
     ItrTypeNotUtf8,
     ItrFuncNotUtf8,
+
+    ItrTypeInvalid,
 }
 
 impl From<Error> for Bytes {

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -10,8 +10,8 @@ pub enum Error {
     ItrNameNotUtf8,
     ItrTypeNotUtf8,
     ItrFuncNotUtf8,
-
     ItrTypeInvalid,
+    MsgIdNotNumber,
 }
 
 impl From<Error> for Bytes {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10,7 +10,7 @@ pub fn parse(input: &[u8]) -> Result<Command, Error> {
     if input.len() < 7 {
         return Err(Error::MalformedCommand);
     }
-    let mut data: Vec<&[u8]> = input.splitn(3, |b| *b == b' ').collect();
+    let mut data: Vec<&[u8]> = input.splitn(3, on_space).collect();
     if data.len() < 3 {
         data.push("".as_bytes());
     }
@@ -24,6 +24,7 @@ pub fn parse(input: &[u8]) -> Result<Command, Error> {
         "ITR LIST" => parse_itr_list(data[2]),
         "ITR ADD" => parse_itr_add(data[2]),
         "ITR DEL" => parse_itr_del(data[2]),
+        "ITR NEXT" => parse_itr_next(data[2]),
         _ => {
             debug!("{:?}", cmd_str);
             Err(Error::UnrecognizedCommand)
@@ -53,7 +54,7 @@ fn parse_log_show(data: &[u8]) -> Result<Command, Error> {
 }
 
 fn parse_msg_add(data: &[u8]) -> Result<Command, Error> {
-    let parts: Vec<&[u8]> = data.splitn(2, |b| *b == b' ').collect();
+    let parts: Vec<&[u8]> = data.splitn(2, on_space).collect();
     match &*parts {
         [log_u8, msg] => match from_utf8(log_u8) {
             Ok(log) => Ok(Command::MsgAdd {
@@ -72,7 +73,7 @@ fn parse_itr_list(data: &[u8]) -> Result<Command, Error> {
     }
 }
 fn parse_itr_add(data: &[u8]) -> Result<Command, Error> {
-    let parts: Vec<&[u8]> = data.splitn(4, |b| *b == b' ').collect();
+    let parts: Vec<&[u8]> = data.splitn(4, on_space).collect();
     match &*parts {
         [raw_log, raw_itr, raw_kind, raw_func] => {
             let log = match from_utf8(raw_log) {
@@ -110,7 +111,7 @@ fn parse_itr_add(data: &[u8]) -> Result<Command, Error> {
     }
 }
 fn parse_itr_del(data: &[u8]) -> Result<Command, Error> {
-    let parts: Vec<&[u8]> = data.splitn(2, |b| *b == b' ').collect();
+    let parts: Vec<&[u8]> = data.splitn(2, on_space).collect();
     match &*parts {
         [raw_log, raw_itr] => {
             let log = match from_utf8(raw_log) {
@@ -127,6 +128,50 @@ fn parse_itr_del(data: &[u8]) -> Result<Command, Error> {
         }
         _ => Err(Error::NotEnoughArguments),
     }
+}
+
+fn parse_itr_next(data: &[u8]) -> Result<Command, Error> {
+    let parts: Vec<&[u8]> = data.splitn(3, on_space).collect();
+    match &*parts {
+        [raw_name, raw_msg_id, raw_count] => {
+            let name = match from_utf8(raw_name) {
+                Ok(itr) => itr.to_owned(),
+                Err(_) => return Err(Error::ItrNameNotUtf8),
+            };
+
+            let msg_id_str = match from_utf8(raw_msg_id) {
+                Ok(msg_id) => msg_id,
+                Err(_) => return Err(Error::MsgIdNotNumber),
+            };
+
+            let msg_id: usize = match msg_id_str.parse() {
+                Ok(msg_id) => msg_id,
+                Err(_) => return Err(Error::MsgIdNotNumber),
+            };
+
+            let count_str = match from_utf8(raw_count) {
+                Ok(count) => count,
+                Err(_) => return Err(Error::MsgIdNotNumber),
+            };
+
+            let count: usize = match count_str.parse() {
+                Ok(count) => count,
+                Err(_) => return Err(Error::MsgIdNotNumber),
+            };
+
+            Ok(Command::ItrNext {
+                name,
+                msg_id,
+                count,
+            })
+        }
+
+        _ => Err(Error::NotEnoughArguments),
+    }
+}
+
+fn on_space(b: &u8) -> bool {
+    *b == b' '
 }
 
 #[cfg(test)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -86,9 +86,13 @@ fn parse_itr_add(data: &[u8]) -> Result<Command, Error> {
             };
 
             let kind = match from_utf8(raw_kind) {
-                Ok(kind) => kind.to_owned(),
+                Ok(kind) => kind.to_owned().to_lowercase(),
                 Err(_) => return Err(Error::ItrTypeNotUtf8),
             };
+
+            if kind != "map" && kind != "filter" && kind != "reduce" {
+                return Err(Error::ItrTypeInvalid);
+            }
 
             let func = match from_utf8(raw_func) {
                 Ok(f) => f.to_owned(),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,4 @@
 /// All tests in this folder assume a server running on localhost:4242
-
 use futures::SinkExt;
 use tokio::net::TcpStream;
 use tokio::stream::StreamExt;
@@ -53,4 +52,14 @@ async fn test_can_create_itr() {
     let mut framer = connect_to_remits().await;
     let itr_cmd = "ITR ADD test_log test_itr \n return msg";
     should_respond_with!(framer, itr_cmd, b"ok");
+}
+
+#[tokio::test]
+async fn test_malformed_msg_add() {
+    let mut framer = connect_to_remits().await;
+    should_respond_with!(framer, "LOG ADD test_log", b"ok");
+
+    // Not valid message pack
+    let msg_cmd = b"MSG ADD test_log \x93\x00\x2a".to_vec();
+    should_respond_with!(framer, msg_cmd, b"err MsgNotValidMessagePack");
 }


### PR DESCRIPTION
This PR adds a validation to the `MSG ADD` command to ensure values passed in are valid MessagePack.  This sets us up for assuming that format for iterators.

Also added some corresponding unit and integration tests.