### PR TITLE
Add (raw, not evaluated) "ITR NEXT" command

### DIFF
--- a/src/db/iters.rs
+++ b/src/db/iters.rs
@@ -1,0 +1,40 @@
+#[derive(Debug, PartialEq, Eq)]
+pub struct Itr {
+    pub log: String,
+    pub name: String,
+    pub func: String,
+    pub kind: ItrKind,
+}
+
+impl Itr {}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ItrKind {
+    Map,
+    Filter,
+    Reduce,
+}
+
+impl PartialEq<String> for ItrKind {
+    fn eq(&self, other: &String) -> bool {
+        use ItrKind::*;
+        let itr_kind = match &**other {
+            "map" => Map,
+            "filter" => Filter,
+            "reduce" => Reduce,
+            _ => return false,
+        };
+
+        *self == itr_kind
+    }
+}
+
+pub fn string_to_kind_unchecked(s: String) -> ItrKind {
+    use ItrKind::*;
+    match &*s {
+        "map" => Map,
+        "filter" => Filter,
+        "reduce" => Reduce,
+        _ => panic!("string_to_kind_unchecked called with unvalidated string"),
+    }
+}

--- a/src/db/iters.rs
+++ b/src/db/iters.rs
@@ -1,3 +1,5 @@
+use super::logs::Log;
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Itr {
     pub log: String,
@@ -6,7 +8,13 @@ pub struct Itr {
     pub kind: ItrKind,
 }
 
-impl Itr {}
+impl Itr {
+    pub fn next(&self, log: &Log, offset: usize, count: usize) -> Vec<Vec<u8>> {
+        // TODO: this will panic if count is out of bounds.
+        // Implement `get` on Log and return None if nothing exists.
+        (0..count).map(|i| log[offset + i].clone()).collect()
+    }
+}
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ItrKind {

--- a/src/db/logs.rs
+++ b/src/db/logs.rs
@@ -45,7 +45,7 @@ mod tests {
     #[test]
     fn test_add_invalid_messagepack_msg() {
         let mut log = Log::new();
-        let buf = vec![ 0x93, 0x00, 0x2a ];
+        let buf = vec![0x93, 0x00, 0x2a];
         if let Ok(_) = log.add_msg(buf) {
             panic!("invalid messagepack was allowed into log");
         };

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,4 +1,5 @@
 mod errors;
+mod iters;
 mod logs;
 mod manifest;
 
@@ -192,7 +193,7 @@ mod tests {
         let _ = db.manifest.add_itr(
             "test".to_owned(),
             "fun".to_owned(),
-            "lua".to_owned(),
+            "map".to_owned(),
             "func".to_owned(),
         );
         assert_eq!(db.manifest.logs.len(), 1);
@@ -215,7 +216,7 @@ mod tests {
             .itr_add(
                 "test".to_owned(),
                 "std_dev avg users".to_owned(),
-                "bf".to_owned(),
+                "map".to_owned(),
                 "+[-->-[>>+>-----<<]<--<---]>-.>>>+.>>..+++[.>]<<<<.+++.------.<<-.>>>>+."
                     .to_owned(),
             )
@@ -224,7 +225,7 @@ mod tests {
             .itr_add(
                 "test2".to_owned(),
                 "std_dev avg users2".to_owned(),
-                "bf".to_owned(),
+                "map".to_owned(),
                 "+[-->-[>>+>-----<<]<--<---]>-.>>>+.>>..+++[.>]<<<<.+++.------.<<-.>>>>+."
                     .to_owned(),
             )
@@ -242,7 +243,7 @@ mod tests {
             .itr_add(
                 "test".to_owned(),
                 "std_dev avg users".to_owned(),
-                "bf".to_owned(),
+                "map".to_owned(),
                 "+[-->-[>>+>-----<<]<--<---]>-.>>>+.>>..+++[.>]<<<<.+++.------.<<-.>>>>+."
                     .to_owned(),
             )
@@ -257,7 +258,7 @@ mod tests {
         let _ = db.itr_add(
             "test".to_owned(),
             "std_dev avg users".to_owned(),
-            "bf".to_owned(),
+            "map".to_owned(),
             "+[-->-[>>+>-----<<]<--<---]>-.>>>+.>>..+++[.>]<<<<.+++.------.<<-.>>>>+.".to_owned(),
         );
         let out = db

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -44,6 +44,11 @@ impl DB {
                 func,
             } => self.itr_add(log, name, kind, func),
             ItrDel { log, name } => self.itr_del(log, name),
+            ItrNext {
+                name,
+                msg_id,
+                count,
+            } => self.itr_next(name, msg_id, count),
         }
     }
 
@@ -116,6 +121,10 @@ impl DB {
     fn itr_del(&mut self, log: String, name: String) -> Result<String, Error> {
         self.manifest.del_itr(log, name)?;
         Ok("ok".to_owned())
+    }
+
+    fn itr_next(&mut self, name: String, msg_id: usize, count: usize) -> Result<String, Error> {
+        unimplemented!();
     }
 }
 

--- a/src/parser/commands.rs
+++ b/src/parser/commands.rs
@@ -19,6 +19,11 @@ pub enum Command {
         log: String,
         name: String,
     },
+    ItrNext {
+        name: String,
+        msg_id: usize,
+        count: usize,
+    },
 }
 
 impl Command {

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -10,6 +10,8 @@ pub enum Error {
     ItrNameNotUtf8,
     ItrTypeNotUtf8,
     ItrFuncNotUtf8,
+
+    ItrTypeInvalid,
 }
 
 impl From<Error> for Bytes {

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -10,8 +10,8 @@ pub enum Error {
     ItrNameNotUtf8,
     ItrTypeNotUtf8,
     ItrFuncNotUtf8,
-
     ItrTypeInvalid,
+    MsgIdNotNumber,
 }
 
 impl From<Error> for Bytes {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10,7 +10,7 @@ pub fn parse(input: &[u8]) -> Result<Command, Error> {
     if input.len() < 7 {
         return Err(Error::MalformedCommand);
     }
-    let mut data: Vec<&[u8]> = input.splitn(3, |b| *b == b' ').collect();
+    let mut data: Vec<&[u8]> = input.splitn(3, on_space).collect();
     if data.len() < 3 {
         data.push("".as_bytes());
     }
@@ -24,6 +24,7 @@ pub fn parse(input: &[u8]) -> Result<Command, Error> {
         "ITR LIST" => parse_itr_list(data[2]),
         "ITR ADD" => parse_itr_add(data[2]),
         "ITR DEL" => parse_itr_del(data[2]),
+        "ITR NEXT" => parse_itr_next(data[2]),
         _ => {
             debug!("{:?}", cmd_str);
             Err(Error::UnrecognizedCommand)
@@ -53,7 +54,7 @@ fn parse_log_show(data: &[u8]) -> Result<Command, Error> {
 }
 
 fn parse_msg_add(data: &[u8]) -> Result<Command, Error> {
-    let parts: Vec<&[u8]> = data.splitn(2, |b| *b == b' ').collect();
+    let parts: Vec<&[u8]> = data.splitn(2, on_space).collect();
     match &*parts {
         [log_u8, msg] => match from_utf8(log_u8) {
             Ok(log) => Ok(Command::MsgAdd {
@@ -72,7 +73,7 @@ fn parse_itr_list(data: &[u8]) -> Result<Command, Error> {
     }
 }
 fn parse_itr_add(data: &[u8]) -> Result<Command, Error> {
-    let parts: Vec<&[u8]> = data.splitn(4, |b| *b == b' ').collect();
+    let parts: Vec<&[u8]> = data.splitn(4, on_space).collect();
     match &*parts {
         [raw_log, raw_itr, raw_kind, raw_func] => {
             let log = match from_utf8(raw_log) {
@@ -110,7 +111,7 @@ fn parse_itr_add(data: &[u8]) -> Result<Command, Error> {
     }
 }
 fn parse_itr_del(data: &[u8]) -> Result<Command, Error> {
-    let parts: Vec<&[u8]> = data.splitn(2, |b| *b == b' ').collect();
+    let parts: Vec<&[u8]> = data.splitn(2, on_space).collect();
     match &*parts {
         [raw_log, raw_itr] => {
             let log = match from_utf8(raw_log) {
@@ -127,6 +128,50 @@ fn parse_itr_del(data: &[u8]) -> Result<Command, Error> {
         }
         _ => Err(Error::NotEnoughArguments),
     }
+}
+
+fn parse_itr_next(data: &[u8]) -> Result<Command, Error> {
+    let parts: Vec<&[u8]> = data.splitn(3, on_space).collect();
+    match &*parts {
+        [raw_name, raw_msg_id, raw_count] => {
+            let name = match from_utf8(raw_name) {
+                Ok(itr) => itr.to_owned(),
+                Err(_) => return Err(Error::ItrNameNotUtf8),
+            };
+
+            let msg_id_str = match from_utf8(raw_msg_id) {
+                Ok(msg_id) => msg_id,
+                Err(_) => return Err(Error::MsgIdNotNumber),
+            };
+
+            let msg_id: usize = match msg_id_str.parse() {
+                Ok(msg_id) => msg_id,
+                Err(_) => return Err(Error::MsgIdNotNumber),
+            };
+
+            let count_str = match from_utf8(raw_count) {
+                Ok(count) => count,
+                Err(_) => return Err(Error::MsgIdNotNumber),
+            };
+
+            let count: usize = match count_str.parse() {
+                Ok(count) => count,
+                Err(_) => return Err(Error::MsgIdNotNumber),
+            };
+
+            Ok(Command::ItrNext {
+                name,
+                msg_id,
+                count,
+            })
+        }
+
+        _ => Err(Error::NotEnoughArguments),
+    }
+}
+
+fn on_space(b: &u8) -> bool {
+    *b == b' '
 }
 
 #[cfg(test)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -86,9 +86,13 @@ fn parse_itr_add(data: &[u8]) -> Result<Command, Error> {
             };
 
             let kind = match from_utf8(raw_kind) {
-                Ok(kind) => kind.to_owned(),
+                Ok(kind) => kind.to_owned().to_lowercase(),
                 Err(_) => return Err(Error::ItrTypeNotUtf8),
             };
+
+            if kind != "map" && kind != "filter" && kind != "reduce" {
+                return Err(Error::ItrTypeInvalid);
+            }
 
             let func = match from_utf8(raw_func) {
                 Ok(f) => f.to_owned(),


### PR DESCRIPTION
This PR builds ontop of the PR from the `message_pack_in_logs` branch.  It should be merged into that one before that is merged into master.

This PR:
- Created a proper Itr struct.
- Removed the ItrRegistrant type which became redundant since we'll likely store the Itr definition directly in the manifest.
- Parses the ITR NEXT command.
- Allows you to get raw Messages out of a Log via the Itr.

There are a few known issues that were left in because they will either be completed by the upcoming Lua work or the Protocol work:
- The `db.itr_next` method returns a `Result<Vec<Vec<u8>>, Error>`, where each Vec<u8> is a record returned in MessagePack format.  Our other functions only return strings right now...so there's a placeholder response until we create the response protocol that can handle the binary return value.
- If the offset + count value runs over the end of the log, it panics. This is obviously really bad, but will be fixed with the Lua work.
- There's like...very little testing. But all the tests would have immediately changed in the next step of the Lua work.

@AndrewScibek I know you've been working on the protocol stuff, it might make sense to rebase ontop of this post merge.  If that seems like it's gonna cause a ton of conflicts then let me know and I can replay your changes ontop of it. 