### PR TITLE
Add macros for different tcp responses

### DIFF
--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -42,14 +42,15 @@ async fn main() {
                     Some(result) => {
                         let output_str = &result.unwrap_or_else(|_| "".into());
                         let output = std::str::from_utf8(output_str).unwrap();
-                        let res = format!("{:?}", output);
-                        if res.chars().nth(1).unwrap() == '!' {
-                            let formated_string = &res.to_string()[2..res.len() -1];
-                            println!("{} {}", "Error".red(),formated_string)
-                        } else {
-                            let formated_string = &res.to_string()[2..res.len() -1];
-                            println!("{} {}", "Success".green(),formated_string)
-                        }
+                        let res = format!("{}", output);
+                        match res.chars().nth(0) {
+                            Some(x) => match x {
+                                '+' => println!("{} {}", "Success".green(), &res[1..]),
+                                '!' => println!("{} {}", "Error".red(), &res[1..]),
+                                _ => println!("{} Unknown return type {}", "Error".red(), x),
+                            },
+                            _ => println!("{} Response is empty", "Error".red()),
+                        };
                     }
                     None => eprintln!("no response from remits"),
                 };

--- a/src/db/errors.rs
+++ b/src/db/errors.rs
@@ -10,12 +10,12 @@ pub enum Error {
 
 impl From<Error> for Bytes {
     fn from(e: Error) -> Self {
-        format!("!{:?}", e).into()
+        format!("{:?}", e).into()
     }
 }
 impl From<Error> for Vec<u8> {
     fn from(e: Error) -> Self {
-        let output: String = format!("!{:?}", e).into();
+        let output: String = format!("{:?}", e).into();
         output.as_bytes().to_vec()
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -57,7 +57,7 @@ impl DB {
                     Ok(_data) => Ok("temporary placeholder for data".to_owned()),
                     Err(e) => Err(e),
                 }
-            },
+            }
         }
     }
 
@@ -132,7 +132,12 @@ impl DB {
         Ok("ok".to_owned())
     }
 
-    fn itr_next(&mut self, name: String, msg_id: usize, count: usize) -> Result<Vec<Vec<u8>>, Error> {
+    fn itr_next(
+        &mut self,
+        name: String,
+        msg_id: usize,
+        count: usize,
+    ) -> Result<Vec<Vec<u8>>, Error> {
         let itr = match self.manifest.itrs.get(&name) {
             Some(itr) => itr,
             None => return Err(Error::ItrDoesNotExist),

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,9 +33,7 @@ macro_rules! format_response {
                 out.into()
             }
             Err(e) => {
-                let mut out: BytesMut = BytesMut::from("!");
-                out.extend_from_slice(&Bytes::from(e));
-                out.into()
+                format_error_response!(e)
             }
         }
     }};

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use futures::SinkExt;
 mod db;
 mod parser;
 
+// Need a better place to store these so they are searchable and not opaque to contributors 
 macro_rules! format_error_response {
     ($err:expr) => {{
         let mut out: BytesMut = BytesMut::from("!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 extern crate log;
 
 use argh::FromArgs;
-use bytes::{BytesMut, Bytes};
+use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 use std::sync::{Arc, Mutex};
@@ -16,7 +16,7 @@ mod db;
 mod parser;
 
 macro_rules! format_error_response {
-    ($err:expr) =>{{
+    ($err:expr) => {{
         let mut out: BytesMut = BytesMut::from("!");
         out.extend_from_slice(&Bytes::from($err));
         out.into()
@@ -24,7 +24,7 @@ macro_rules! format_error_response {
 }
 
 macro_rules! format_success_response {
-    ($resp:expr) =>{{
+    ($resp:expr) => {{
         let mut out: BytesMut = BytesMut::from("+");
         out.extend_from_slice(&Bytes::from($resp));
         out.into()
@@ -86,12 +86,8 @@ async fn handle_socket(db: Arc<Mutex<db::DB>>, socket: TcpStream) {
 
         let out = db.lock().unwrap().exec(cmd);
         let resp = match out {
-            Ok(res) => {
-                format_success_response!(res)
-            }
-            Err(e) => {
-                format_error_response!(e)
-            }
+            Ok(res) => format_success_response!(res),
+            Err(e) => format_error_response!(e),
         };
 
         debug!("responding with: {:?}", resp);

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -16,6 +16,6 @@ pub enum Error {
 
 impl From<Error> for Bytes {
     fn from(e: Error) -> Self {
-        format!("!{:?}", e).into()
+        format!("{:?}", e).into()
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -61,5 +61,5 @@ async fn test_malformed_msg_add() {
 
     // Not valid message pack
     let msg_cmd = b"MSG ADD test_log \x93\x00\x2a".to_vec();
-    should_respond_with!(framer, msg_cmd, b"err MsgNotValidMessagePack");
+    should_respond_with!(framer, msg_cmd, b"!MsgNotValidMessagePack");
 }


### PR DESCRIPTION
My first macros written in rust so Im not sure where they usually are put and the syntax is a mess so hopefully these make sense. 

The goal of this pr is the make returning different msg types repeatable and in one place