### PR TITLE
Run integration tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,5 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --bin remits --verbose
+    - name: Run server
+      run: cargo run
     - name: Run tests
-      run: cargo test --bins --verbose
+      run: cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,8 +19,6 @@ jobs:
       run: rustfmt --check --edition 2018 ./src/**/*.rs
     - name: Clippy
       run: rustup component add clippy && cargo clippy --all-targets -- -D warnings
-
-# echo ./src/**/*.rs
     - name: Run server
       run: cargo run &
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Clippy
+      run: rustup component add clippy && cargo clippy --all-targets -- -D warnings
     - name: Build
       run: cargo build --bin remits --verbose
     - name: Run server

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,6 @@ jobs:
     - name: Build
       run: cargo build --bin remits --verbose
     - name: Run server
-      run: cargo run
+      run: cargo run &
     - name: Run tests
       run: cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,10 +13,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Clippy
-      run: rustup component add clippy && cargo clippy --all-targets -- -D warnings
     - name: Build
       run: cargo build --bin remits --verbose
+    - name: Fmt
+      run: rustfmt --check --edition 2018 ./src/**/*.rs
+    - name: Clippy
+      run: rustup component add clippy && cargo clippy --all-targets -- -D warnings
+
+# echo ./src/**/*.rs
     - name: Run server
       run: cargo run &
     - name: Run tests

--- a/src/bin/client.rs
+++ b/src/bin/client.rs
@@ -42,8 +42,8 @@ async fn main() {
                     Some(result) => {
                         let output_str = &result.unwrap_or_else(|_| "".into());
                         let output = std::str::from_utf8(output_str).unwrap();
-                        let res = format!("{}", output);
-                        match res.chars().nth(0) {
+                        let res = output.to_string();
+                        match res.chars().next() {
                             Some(x) => match x {
                                 '+' => println!("{} {}", "Success".green(), &res[1..]),
                                 '!' => println!("{} {}", "Error".red(), &res[1..]),

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,12 +52,10 @@ impl ::std::default::Default for RemitsConfig {
 }
 
 fn setup_logger(config_level: Option<String>, flag_level: Option<String>) {
-    let log_level = &flag_level.unwrap_or(
-        config_level
+    let log_level = &flag_level.unwrap_or_else(|| config_level
             .as_ref()
             .unwrap_or(&"info".to_owned())
-            .to_string(),
-    );
+            .to_string());
     Builder::new()
         .parse_filters(log_level)
         .target(Target::Stdout)

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,10 +52,12 @@ impl ::std::default::Default for RemitsConfig {
 }
 
 fn setup_logger(config_level: Option<String>, flag_level: Option<String>) {
-    let log_level = &flag_level.unwrap_or_else(|| config_level
+    let log_level = &flag_level.unwrap_or_else(|| {
+        config_level
             .as_ref()
             .unwrap_or(&"info".to_owned())
-            .to_string());
+            .to_string()
+    });
     Builder::new()
         .parse_filters(log_level)
         .target(Target::Stdout)

--- a/src/db/iters.rs
+++ b/src/db/iters.rs
@@ -35,7 +35,7 @@ impl Itr {
                     }
                 };
 
-                globals.set("msg", lua_msg);
+                globals.set("msg", lua_msg).expect("could not set global");
                 let res = ctx.load(&*self.func).eval::<rlua::Value>();
                 if let Err(e) = res {
                     debug!("error running lua: {:?} {:?}", e, msg);
@@ -50,13 +50,14 @@ impl Itr {
                 };
                 let mut serializer = serde_cbor::Serializer::new(&mut buf);
                 match serde_transcode::transcode(deserializer, &mut serializer) {
-                    Ok(ok) => (),
+                    Ok(_ok) => (),
                     Err(e) => {
                         debug!("error transcoding lua to msgpack: {:?} {:?}", e, value);
                         error = Some(Error::ErrReadingLuaResponse);
                     }
                 };
 
+            
                 output.push(buf);
             }
         });

--- a/src/db/iters.rs
+++ b/src/db/iters.rs
@@ -57,7 +57,6 @@ impl Itr {
                     }
                 };
 
-            
                 output.push(buf);
             }
         });

--- a/src/db/logs.rs
+++ b/src/db/logs.rs
@@ -47,6 +47,6 @@ mod tests {
     fn test_add_invalid_cbor_msg() {
         let mut log = Log::new();
         let buf = vec![0x1a, 0x01, 0x02];
-        assert_eq!(log.add_msg(buf).is_err(),true);
+        assert_eq!(log.add_msg(buf).is_err(), true);
     }
 }

--- a/src/db/logs.rs
+++ b/src/db/logs.rs
@@ -14,7 +14,7 @@ impl Log {
 
     pub fn add_msg(&mut self, msg: Vec<u8>) -> Result<(), Error> {
         let res: Result<CborValue, CborError> = serde_cbor::from_reader(&mut &*msg);
-        if let Err(e) = res {
+        if let Err(_e) = res {
             return Err(Error::MsgNotValidCbor);
         }
         self.data.push(msg);
@@ -47,8 +47,6 @@ mod tests {
     fn test_add_invalid_cbor_msg() {
         let mut log = Log::new();
         let buf = vec![0x1a, 0x01, 0x02];
-        if let Ok(_) = log.add_msg(buf) {
-            panic!("invalid messagepack was allowed into log");
-        };
+        assert_eq!(log.add_msg(buf).is_err(),true);
     }
 }

--- a/src/db/manifest.rs
+++ b/src/db/manifest.rs
@@ -63,7 +63,7 @@ impl Manifest {
         let itr = Itr {
             log,
             name: name.clone(),
-            kind: kind,
+            kind,
             func,
         };
 
@@ -160,7 +160,7 @@ mod tests {
             manifest.add_itr("test".into(), "fun".into(), "map".into(), "func2".into());
         assert_eq!(
             format!("{:?}", duplicate_error),
-            format!("Err(ItrExistsWithSameName)")
+            "Err(ItrExistsWithSameName)".to_string()
         );
     }
 
@@ -177,7 +177,7 @@ mod tests {
         let does_not_exist_error = manifest.del_itr("test".into(), "fun".into());
         assert_eq!(
             format!("{:?}", does_not_exist_error),
-            format!("Err(ItrDoesNotExist)")
+            "Err(ItrDoesNotExist)".to_string()
         );
         // Neither function or log exist
         let _ = manifest.add_itr("test".into(), "fun".into(), "map".into(), "func".into());
@@ -185,7 +185,7 @@ mod tests {
         let log_does_not_exist_error = manifest.del_itr("test1".into(), "fun".into());
         assert_eq!(
             format!("{:?}", log_does_not_exist_error),
-            format!("Err(ItrDoesNotExist)")
+            "Err(ItrDoesNotExist)".to_string()
         );
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -229,14 +229,14 @@ mod tests {
         };
 
         assert_eq!(db.logs.len(), 1);
-        assert_eq!(db.logs["test"][0], msg.clone());
+        assert_eq!(db.logs["test"][0], msg);
     }
 
     #[test]
     fn test_db_msg_add_log_dne() {
         let mut db = DB::new();
-        match db.msg_add("test".into(), "hello".as_bytes().to_vec()) {
-            Response::Error(e) => (),
+        match db.msg_add("test".into(), b"hello".to_vec()) {
+            Response::Error(_e) => (),
             _ => panic!("expected response to be an error"),
         }
     }
@@ -250,7 +250,7 @@ mod tests {
             "fun".into(),
             "map".into(),
             "return msg".into(),
-        );
+        ).unwrap();// its a test
         assert_eq!(db.manifest.logs.len(), 1);
 
         match db.log_delete("test".into()) {
@@ -284,8 +284,8 @@ mod tests {
                 let first: String = serde_cbor::from_slice(&*(bytes[0])).unwrap();
                 let secnd: String = serde_cbor::from_slice(&*(bytes[1])).unwrap();
                 assert!(
-                    (first == "i1".to_owned() && secnd == "i2".to_owned())
-                        || (secnd == "i1".to_owned() && first == "i2".to_owned())
+                    (first == "i1" && secnd == "i2")
+                        || (secnd == "i1" && first == "i2")
                 );
             }
             _ => panic!("expected itr_list to return data"),

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -247,7 +247,6 @@ mod tests {
         db.log_add("test".into());
         db.manifest
             .add_itr(
-                
                 "test".into(),
                 "fun".into(),
                 "map".into(),

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -245,12 +245,15 @@ mod tests {
     fn test_db_log_del() {
         let mut db = DB::new();
         db.log_add("test".into());
-        db.manifest.add_itr(
-            "test".into(),
-            "fun".into(),
-            "map".into(),
-            "return msg".into(),
-        ).unwrap();// its a test
+        db.manifest
+            .add_itr(
+                
+                "test".into(),
+                "fun".into(),
+                "map".into(),
+                "return msg".into(),
+            )
+            .unwrap(); // its a test
         assert_eq!(db.manifest.logs.len(), 1);
 
         match db.log_delete("test".into()) {
@@ -283,10 +286,7 @@ mod tests {
             Response::Data(bytes) => {
                 let first: String = serde_cbor::from_slice(&*(bytes[0])).unwrap();
                 let secnd: String = serde_cbor::from_slice(&*(bytes[1])).unwrap();
-                assert!(
-                    (first == "i1" && secnd == "i2")
-                        || (secnd == "i1" && first == "i2")
-                );
+                assert!((first == "i1" && secnd == "i2") || (secnd == "i1" && first == "i2"));
             }
             _ => panic!("expected itr_list to return data"),
         };

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,8 +30,8 @@ pub enum Error {
 }
 
 impl Error {
-    pub fn to_bytes(self) -> Vec<u8> {
-        serde_cbor::to_vec(&self).unwrap()
+    pub fn to_bytes(&self) -> Vec<u8> {
+        serde_cbor::to_vec(self).unwrap()
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -13,7 +13,7 @@ static OK_RESP: &[u8] = &[0x62, 0x6F, 0x6B];
 
 #[tokio::test]
 async fn integration_tests() {
-    let ref mut framer = connect_to_remits().await;
+    let framer = &mut (connect_to_remits().await);
 
     println!("test: should be able to add a log");
     let (kind, code, payload) = send_req(framer, new_log_add_req("test")).await;
@@ -176,7 +176,7 @@ async fn send_req(
         .expect("no response from remits")
         .expect("could not understand response");
 
-    return (result[0], result[1], result[2..].to_vec());
+    (result[0], result[1], result[2..].to_vec())
 }
 
 async fn connect_to_remits() -> Framed<TcpStream, LengthDelimitedCodec> {


### PR DESCRIPTION
I am on a mission to prevent failing tests from getting to master


> Integration Tests for Binary Crates
> 
> If our project is a binary crate that only contains a src/main.rs file and doesn’t have a src/lib.rs file, we can’t create integration tests in the tests directory and bring functions defined in the src/main.rs file into scope with a use statement. Only library crates expose functions that other crates can use; binary crates are meant to be run on their own.
> 
> This is one of the reasons Rust projects that provide a binary have a straightforward src/main.rs file that calls logic that lives in the src/lib.rs file. Using that structure, integration tests can test the library crate with use to make the important functionality available. If the important functionality works, the small amount of code in the src/main.rs file will work as well, and that small amount of code doesn’t need to be tested.

https://doc.rust-lang.org/book/ch11-03-test-organization.html